### PR TITLE
absolute.size not needed in width/heightDetails

### DIFF
--- a/R/align.r
+++ b/R/align.r
@@ -18,12 +18,24 @@
 #  # when this function is not exported. Uncomment when this function
 #  # is fixed and exported again.
 #  # gtable_join(a, b)
-gtable_join <- function(x, y, along = 1L, join = "left") {
+gtable_join <- function(x, y, along = 1L, join = "outer") {
   aligned <- gtable_align(x, y, along = along, join = join)
   switch(along,
-    cbind(aligned$x, aligned$y), 
-    rbind(aligned$x, aligned$y),
-    stop("along > 2 no implemented"))
+         cbind_gtable(aligned$x, aligned$y,
+                      size="max"),
+         rbind_gtable(aligned$x, aligned$y,
+                      size="max"),
+         stop("along > 2 no implemented"))
+}
+
+#' @export
+join <- function (..., along = 1L, join = "outer")
+{
+  gtables <- list(...)
+  Reduce(function(x, y) gtable_join(x, y,
+                                    along = along,
+                                    join = join),
+         gtables)
 }
 
 #  Align two gtables based on their row/col names.
@@ -39,25 +51,25 @@ gtable_join <- function(x, y, along = 1L, join = "left") {
 #    in to a single gtable.
 #  @return a list with elements \code{x} and \code{y} corresponding to the
 #    input gtables with extra rows/columns so that they now align.
-gtable_align <- function(x, y, along = 1L, join = "left") {
+gtable_align <- function(x, y, along = 1L, join = "outer") {
   join <- match.arg(join, c("left", "right", "inner", "outer"))
-  
+
   names_x <- dimnames(x)[[along]]
   names_y <- dimnames(y)[[along]]
-  
+
   if (is.null(names_x) || is.null(names_y)) {
     stop("Both gtables must have names along dimension to be aligned")
   }
-  
+
   idx <- switch(join,
-    left = names_x,
-    right = names_y, 
-    inner = intersect(names_x, names_y),
-    outer = union(names_x, names_y)
+                left = names_x,
+                right = names_y,
+                inner = intersect(names_x, names_y),
+                outer = union(names_x, names_y)
   )
-  
+
   list(
-    x = gtable_reindex(x, idx, along), 
+    x = gtable_reindex(x, idx, along),
     y = gtable_reindex(y, idx, along)
   )
 }
@@ -71,42 +83,43 @@ gtable_align <- function(x, y, along = 1L, join = "left") {
 #  rownames(gtable:::gtable_reindex(gt, c("a", "b")))
 #  rownames(gtable:::gtable_reindex(gt, c("a")))
 #  rownames(gtable:::gtable_reindex(gt, c("a", "d", "e")))
-gtable_reindex <- function(x, index, along = 1) {
+
+gtable_reindex <- function(x, index, along = 1L) {
   stopifnot(is.character(index))
   if (length(dim(x)) > 2L || along > 2L) {
     stop("reindex only supports 2d objects")
   }
   old_index <- switch(along, rownames(x), colnames(x))
   stopifnot(!is.null(old_index))
-  
+
   if (identical(index, old_index)) {
     return(x)
   }
-  
+
   if (!(old_index %contains% index)) {
     missing <- setdiff(index, old_index)
     # Create and add dummy space rows
-    
+
     if (along == 1L) {
       spacer <- gtable(
-        widths = unit(rep(0, ncol(x)), "cm"), 
+        widths = unit(rep(0, ncol(x)), "cm"),
         heights = rep_along(unit(0, "cm"), missing),
         rownames = missing)
       x <- rbind(x, spacer, size = "first")
     } else if (along == 2L){
       spacer <- gtable(
-        heights = unit(rep(0, nrow(x)), "cm"), 
+        heights = unit(rep(0, nrow(x)), "cm"),
         widths = rep_along(unit(0, "cm"), missing),
         colnames = missing)
-      
+
       x <- cbind(x, spacer, size = "first")
     }
   }
-  
-  
+
+
   # Reorder & subset
-  
-  switch(along, 
+
+  switch(along,
          x[index, ],
          x[, index])
 }

--- a/R/grid.r
+++ b/R/grid.r
@@ -23,10 +23,10 @@ vpname <- function(row) {
 }
 
 #' @export
-widthDetails.gtable <- function(x) absolute.size(gtable_width(x))
+widthDetails.gtable <- function(x) gtable_width(x)
 
 #' @export
-heightDetails.gtable <- function(x) absolute.size(gtable_height(x))
+heightDetails.gtable <- function(x) gtable_height(x)
 
 #' @export
 makeContext.gtable <- function(x) {

--- a/R/gtable.r
+++ b/R/gtable.r
@@ -256,3 +256,26 @@ gtable_height <- function(x) sum(x$heights)
 #' @param x A gtable object
 #' @export
 gtable_width <- function(x) sum(x$widths)
+
+
+#'  Prints summary information of gtable objects
+#'  @param object a gtable
+#'  @param ... unused
+#'  @importFrom utils str
+#'  @export
+str.gtable <- function(object, ...){
+  cat(c("gtable, containing \ngrobs (", 
+        length(object[["grobs"]]), ") :"), sep="")
+  utils::str(vapply(object$grobs, as.character, character(1)))
+  cat("layout :\n")
+  utils::str(object[["layout"]])
+  cat("widths :\nunit vector of length", 
+      length(object[["widths"]]), "\n")
+  cat("heights :\nunit vector of length", 
+      length(object[["heights"]]), "\n")
+  for(element in c("respect", "rownames", 
+                   "name", "gp", "vp")){
+    cat(element, ":\n")
+    utils::str(object[[element]])
+  }
+}

--- a/R/rbind-cbind.r
+++ b/R/rbind-cbind.r
@@ -39,8 +39,8 @@ rbind_gtable <- function(x, y, size = "max") {
   x$widths <- switch(size,
     first = x$widths,
     last = y$widths,
-    min = compare_unit(x$widths, y$widths, pmin),
-    max = compare_unit(x$widths, y$widths, pmax)
+    min = unit.pmin(x$widths, y$widths),
+    max = unit.pmax(x$widths, y$widths)
   )
 
   x$grobs <- append(x$grobs, y$grobs)
@@ -49,6 +49,7 @@ rbind_gtable <- function(x, y, size = "max") {
 }
 
 #' @rdname bind
+#' @importFrom grid unit.pmax unit.pmin
 #' @method cbind gtable
 #' @export
 cbind.gtable <- function(..., size = "max", z = NULL) {
@@ -75,9 +76,9 @@ cbind_gtable <- function(x, y, size = "max") {
   x$heights <- switch(size,
     first = x$heights,
     last = y$heights,
-    min = compare_unit(x$heights, y$heights, pmin),
-    max = compare_unit(x$heights, y$heights, pmax)
-  )
+    min = unit.pmin(x$heights, y$heights),
+    max = unit.pmax(x$heights, y$heights)
+    )
 
   x$grobs <- append(x$grobs, y$grobs)
 

--- a/R/trim.r
+++ b/R/trim.r
@@ -34,3 +34,15 @@ gtable_trim <- function(x) {
 
   x
 }
+
+
+gtable_remove_grob <- function(x, pattern, which = 1L,
+                               fixed = FALSE, trim=TRUE){
+  matches <- grep(pattern, x$layout$name, fixed = fixed)
+  tokeep <- setdiff(seq_len(length(x)), matches[which])
+  x$layout <- x$layout[tokeep, , drop = FALSE]
+  x$grobs <- x$grobs[tokeep]
+  if(trim)
+    x <- gtable_trim(x)
+  x
+}


### PR DESCRIPTION
cf email discussion with Paul Murrell, Hadley and Winston (23/07/2015):
no-one seems to remember why `absolute.units` was used here in the first
place. But it is rather inconvenient in practice -- consider this one example for illustration:

```
absolute.size(unit.c(unit(1,"npc"), 
                      unit(1,"grobwidth", data=textGrob("label"))))
[1] 1null 1null
```

Not what’s usually intended, and problematic if one wants a tight layout based on the string width.